### PR TITLE
Add cloud execution to main pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,3 +16,8 @@ steps:
 - script: |
     k6 run loadtests/local.js
   displayName: Run k6 load test within Azure Pipelines
+
+- script: |
+    k6 login cloud --token $(k6cloud.token)
+    k6 cloud --quiet loadtests/cloud.js
+  displayName: Run k6 cloud load test within Azure Pipelines


### PR DESCRIPTION
It was disabled because of a bug on GitHub / Azure integration. It was not possible to unlink old Mislav's pipeline.